### PR TITLE
Extend CheckExternal example

### DIFF
--- a/chapters/06-smart-contracts-in-ralph.md
+++ b/chapters/06-smart-contracts-in-ralph.md
@@ -1242,8 +1242,7 @@ Contract CarFactory(mut carId: ByteVec) {
         initialPrice: U256
     ) -> Car {
         let (immFields, mutFields) = Car.encodeFields!(model, year, initialPrice)
-        carId = copyCreateContract!{callerAddress!() -> ALPH: mini
-malContractDeposit!()}(
+        carId = copyCreateContract!{callerAddress!() -> ALPH: minimalContractDeposit!()}(
             carContractId, immFields, mutFields
         )
         return Car(carId)

--- a/chapters/06-smart-contracts-in-ralph.md
+++ b/chapters/06-smart-contracts-in-ralph.md
@@ -1007,7 +1007,6 @@ import { CheckExternal } from '../artifacts/ts'
 
 async function test() {
   web3.setCurrentNodeProvider('http://127.0.0.1:22973')
-  const nodeProvider = web3.getCurrentNodeProvider()
 
   const signer = await getSigner()
   const { contractInstance: checkExternal } = await CheckExternal.deploy(signer, {

--- a/chapters/06-smart-contracts-in-ralph.md
+++ b/chapters/06-smart-contracts-in-ralph.md
@@ -634,7 +634,7 @@ import { getSigner } from '@alephium/web3-test'
 import { Counters } from '../artifacts/ts'
 
 async function test() {
-  web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
+  web3.setCurrentNodeProvider('http://127.0.0.1:22973')
 
   const signer = await getSigner()
   const { contractInstance: counters } = await Counters.deploy(
@@ -769,7 +769,7 @@ import { getSigner, mintToken } from '@alephium/web3-test'
 import { Burn } from '../artifacts/ts'
 
 async function test() {
-  web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
+  web3.setCurrentNodeProvider('http://127.0.0.1:22973')
   const nodeProvider = web3.getCurrentNodeProvider()
 
   const signer = await getSigner()
@@ -826,7 +826,7 @@ import { getSigner, mintToken } from '@alephium/web3-test'
 import { Withdraw } from '../artifacts/ts'
 
 async function test() {
-  web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
+  web3.setCurrentNodeProvider('http://127.0.0.1:22973')
   const nodeProvider = web3.getCurrentNodeProvider()
 
   const signer = await getSigner()
@@ -890,7 +890,7 @@ import { getSigner, mintToken } from '@alephium/web3-test'
 import { Deposit, DepositTwice } from '../artifacts/ts'
 
 async function test() {
-  web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
+  web3.setCurrentNodeProvider('http://127.0.0.1:22973')
   const nodeProvider = web3.getCurrentNodeProvider()
 
   const signer = await getSigner()
@@ -1077,7 +1077,7 @@ import { getSigner } from '@alephium/web3-test'
 import { FunctionCalls, Fib } from '../artifacts/ts'
 
 async function test() {
-  web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
+  web3.setCurrentNodeProvider('http://127.0.0.1:22973')
 
   const signer = await getSigner()
   const { contractInstance: fib } = await Fib.deploy(signer, { initialFields: {} })
@@ -3369,7 +3369,7 @@ In the integration test, the `TokenFaucet` contract is deployed to the devnet an
 ```typescript
 describe('integration tests', () => {
   beforeAll(async () => {
-    web3.setCurrentNodeProvider('http://127.0.0.1:22973', undefined, fetch)
+    web3.setCurrentNodeProvider('http://127.0.0.1:22973')
   })
 
   it('should withdraw on devnet', async () => {


### PR DESCRIPTION
@h0ngcha0 what do you think about this? I think it illustrates even better how the `checkCaller!` prevents unauthorized mutation of the contract fields.