### PR TITLE
Fix typo and CarFactory contract example

### DIFF
--- a/chapters/06-smart-contracts-in-ralph.md
+++ b/chapters/06-smart-contracts-in-ralph.md
@@ -1299,7 +1299,7 @@ import { Car, CarFactory } from '../artifacts/ts'
 
 async function test() {
   web3.setCurrentNodeProvider('http://127.0.0.1:22973')
-  const nodeProvider = new NodeProvider('http://127.0.0.1:22973')
+  const nodeProvider = web3.getCurrentNodeProvider()
 
   const signer = await getSigner()
   const carInfos = { model: stringToHex('Toyota'), year: 2020n, price: 10000n }

--- a/chapters/06-smart-contracts-in-ralph.md
+++ b/chapters/06-smart-contracts-in-ralph.md
@@ -1285,7 +1285,7 @@ Contracts in Alephium have both immutable and mutable fields, which are stored a
 
 `copyCreateCarWithToken` is similar to `copyCreateCar`, but it also allows you to issue a specific amount of tokens for the newly created contract using the `copyCreateContractWithToken!` built-in function.
 
-In Alephium, tokens are issued through contract creation, and the token ID is exactly the same as the contract ID. By default, the issued tokens will be owned by the contract itself. However, `copyCreateContractWithToken!` provides also allows you to specify a recipient for the issued tokens.
+In Alephium, tokens are issued through contract creation, and the token ID is exactly the same as the contract ID. By default, the issued tokens will be owned by the contract itself. However, `copyCreateContractWithToken!` allows you to specify a recipient for the issued tokens.
 
 Let's test the `Car` and `CarFactory` contracts using the TypeScript code below:
 

--- a/chapters/06-smart-contracts-in-ralph.md
+++ b/chapters/06-smart-contracts-in-ralph.md
@@ -1367,7 +1367,6 @@ Contract OldCode(owner: Address, n: U256) {
         migrate!(newCode)
     }
 
-    // Please check owner in production code
     @using(updateFields = true)
     pub fn migrateWithFields(newCode: ByteVec, newN: U256) -> () {
         checkCaller!(callerAddress!() == owner, 0)

--- a/chapters/06-smart-contracts-in-ralph.md
+++ b/chapters/06-smart-contracts-in-ralph.md
@@ -1362,7 +1362,6 @@ Contract OldCode(owner: Address, n: U256) {
         return n
     }
 
-    @using(checkExternalCaller = false)
     pub fn migrate(newCode: ByteVec) -> () {
         checkCaller!(callerAddress!() == owner, 0)
         migrate!(newCode)


### PR DESCRIPTION
@h0ngcha0 even after my fixes to the car factory contract, the TS script is failing with this error due to this line. I haven't figured out how to fix it yet.

```ts
const carTokenId = binToHex(tokenIdFromAddress(carAddress))
```

```
npx ts-node src/carFactory.ts
/Users/ilias/dev/alephium/_test-projects/hello-web3/node_modules/@alephium/web3/dist/src/utils/bs58.js:46
        throw new error_1.TraceableError(`Invalid base58 string ${s}`, e);
              ^
TraceableError: Invalid base58 string 65f47b143a6a577f5ef15ae58e58a09ac5c1fc2ce5d1e2e94f907c463d5da800, error: Non-base58 character
    at base58ToBytes (/Users/ilias/dev/alephium/_test-projects/hello-web3/node_modules/@alephium/web3/dist/src/utils/bs58.js:46:15)
    at idFromAddress (/Users/ilias/dev/alephium/_test-projects/hello-web3/node_modules/@alephium/web3/dist/src/address/address.js:162:46)
    at tokenIdFromAddress (/Users/ilias/dev/alephium/_test-projects/hello-web3/node_modules/@alephium/web3/dist/src/address/address.js:158:12)
    at test (/Users/ilias/dev/alephium/_test-projects/hello-web3/src/carFactory.ts:45:49)
    at processTicksAndRejections (node:internal/process/task_queues:95:5) {
  trace: Error: Non-base58 character
      at Object.decode (/Users/ilias/dev/alephium/_test-projects/hello-web3/node_modules/base-x/src/index.js:113:11)
      at base58ToBytes (/Users/ilias/dev/alephium/_test-projects/hello-web3/node_modules/@alephium/web3/dist/src/utils/bs58.js:43:29)
      at idFromAddress (/Users/ilias/dev/alephium/_test-projects/hello-web3/node_modules/@alephium/web3/dist/src/address/address.js:162:46)
      at tokenIdFromAddress (/Users/ilias/dev/alephium/_test-projects/hello-web3/node_modules/@alephium/web3/dist/src/address/address.js:158:12)
      at test (/Users/ilias/dev/alephium/_test-projects/hello-web3/src/carFactory.ts:45:49)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
}
```